### PR TITLE
Add Endpoint for Average Sensor Readings with Timestamp Filter

### DIFF
--- a/src/controllers/SensorReadingController.ts
+++ b/src/controllers/SensorReadingController.ts
@@ -82,6 +82,46 @@ class SensorReadingController {
     }
   }
 
+  async average(req: Request, res: Response) {
+    try {
+      const { timestamp } = req.query as {
+        timestamp: TimestampFilter;
+      };
+
+      let timestampFilter: Date;
+      const currentDate = new Date();
+
+      switch (timestamp) {
+        case "24hours":
+          timestampFilter = subHours(currentDate, 24);
+          break;
+        case "48hours":
+          timestampFilter = subHours(currentDate, 48);
+          break;
+        case "1week":
+          timestampFilter = subWeeks(currentDate, 1);
+          break;
+        case "1month":
+          timestampFilter = subMonths(currentDate, 1);
+          break;
+        default:
+          timestampFilter = subHours(currentDate, 24);
+      }
+
+      const { statusCode, body } = await this.sensorReadingService.getAverage({
+        timestamp: timestampFilter,
+      });
+
+      res.status(statusCode).send(body);
+    } catch (error: any) {
+      console.error("Error to get average sensor reading:", error);
+      res.status(500).send({
+        message: "An error occurred while getting the average sensor reading",
+        error: error.message,
+      });
+    }
+  }
+
   async upload(req: Request, res: Response): Promise<void> {
     if (!req.file) {
       res.status(400).json({ error: "No file uploaded" });

--- a/src/middlewares/validate.sensor-reading.middleware.ts
+++ b/src/middlewares/validate.sensor-reading.middleware.ts
@@ -59,6 +59,23 @@ export const validateSensorReadingPagination: RequestHandler[] = [
   },
 ];
 
+export const validateGetSensorReadingAverage: RequestHandler[] = [
+  query("timestamp")
+    .optional()
+    .isIn(["24hours", "48hours", "1week", "1month"])
+    .withMessage(
+      "Timestamp must be one of the following: '24hours', '48hours', '1week', '1month'"
+    ),
+
+  (req: Request, res: Response, next: NextFunction): void => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ errors: errors.array() });
+    }
+    next();
+  },
+];
+
 export function validateFileMiddleware(
   req: Request,
   res: Response,

--- a/src/repositories/SensorReadingRepository.ts
+++ b/src/repositories/SensorReadingRepository.ts
@@ -44,6 +44,22 @@ class SensorReadingRepository {
     }
   }
 
+  async getAverage(timestamp: Date) {
+    const averages = await prisma.sensorReading.groupBy({
+      by: ["equipmentId"],
+      _avg: {
+        value: true,
+      },
+      where: {
+        timestamp: {
+          gte: timestamp,
+        },
+      },
+    });
+
+    return averages;
+  }
+
   async paginate({
     where,
     pagination,

--- a/src/routes/sensorReadingRoutes.ts
+++ b/src/routes/sensorReadingRoutes.ts
@@ -10,6 +10,7 @@ import {
   validatePostSensorReading,
   validateFileMiddleware,
   validateSensorReadingPagination,
+  validateGetSensorReadingAverage,
 } from "../middlewares/validate.sensor-reading.middleware";
 
 const router = express.Router();
@@ -139,6 +140,64 @@ router.get(
  *               error: error details
  */
 
+router.get(
+  "/average",
+  AuthMiddleware,
+  validateGetSensorReadingAverage,
+  (req: Request, res: Response) => sensorReadingController.average(req, res)
+);
+
+/**
+ * @openapi
+ * /sensor-reading/average:
+ *   get:
+ *     description: Get average sensor readings
+ *     tags: [Sensor Reading]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: timestamp
+ *         schema:
+ *           type: string
+ *           enum: [24hours, 48hours, 1week, 1month]
+ *         description: Filter by time range (24 hours, 48 hours, 1 week, or 1 month)
+ *     responses:
+ *       200:
+ *         description: Returns average sensor readings
+ *         content:
+ *           application/json:
+ *             example:
+ *               - _avg:
+ *                   value: 73.25
+ *                 equipmentId: "EQ-12496"
+ *               - _avg:
+ *                   value: 75.90333333333334
+ *                 equipmentId: "EQ-12495"
+ *       400:
+ *         description: Invalid request parameters
+ *         content:
+ *           application/json:
+ *             example:
+ *               message: Invalid query parameters
+ *               errors:
+ *                 - msg: "Timestamp must be one of the following: '24hours', '48hours', '1week', '1month'"
+ *                   param: "timestamp"
+ *                   location: "query"
+ *       401:
+ *         description: Unauthorized - missing or invalid Bearer token
+ *         content:
+ *           application/json:
+ *             example:
+ *               message: Unauthorized access
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             example:
+ *               message: An error occurred while paginating sensor readings
+ *               error: error details
+ */
 router.post(
   "/upload",
   AuthMiddleware,

--- a/src/services/SensorReadingService.ts
+++ b/src/services/SensorReadingService.ts
@@ -2,6 +2,7 @@ import HttpResponse from "../utils/HttpResponse";
 import SensorReadingRepository from "../repositories/SensorReadingRepository";
 import { PaginationRequest } from "../interfaces/PaginationInterface";
 import { Prisma } from "@prisma/client";
+import { TimestampFilter } from "../repositories/SensorReadingRepository";
 
 export class SensorReadingService {
   private sensorReadingService: SensorReadingRepository;
@@ -26,6 +27,16 @@ export class SensorReadingService {
       const sensor_reading = await this.sensorReadingService.createMany(data);
 
       return HttpResponse.created(sensor_reading);
+    } catch (error) {
+      console.error(error);
+      return HttpResponse.serverError();
+    }
+  }
+
+  async getAverage({ timestamp }: { timestamp: Date }) {
+    try {
+      const averages = await this.sensorReadingService.getAverage(timestamp);
+      return HttpResponse.ok(averages);
     } catch (error) {
       console.error(error);
       return HttpResponse.serverError();


### PR DESCRIPTION
### Description

This pull request introduces a new API endpoint to fetch the average sensor readings based on a specified time range. The endpoint allows filtering by different time periods such as the last 24 hours, 48 hours, 1 week, or 1 month.

#### Features:
- **Average Sensor Readings Calculation:** 
  - The `average` method in the `sensorReadingController` calculates the average reading for each sensor (`equipmentId`) within a specified time range.
  - The time range is determined by the `timestamp` query parameter, which can accept the following values: `24hours`, `48hours`, `1week`, and `1month`.
  
- **Query Parameter Validation:**
  - The `validateGetSensorReadingAverage` middleware ensures that the `timestamp` query parameter is one of the allowed values.
  - If invalid, the API responds with a `400` status and an error message indicating the allowed values.

- **Prisma Integration:**
  - The `getAverage` method in the `sensorReadingService` uses Prisma to group sensor readings by `equipmentId` and calculates the average value for each group where the timestamp is greater than or equal to the specified filter.

- **API Documentation:**
  - OpenAPI documentation is included for the new endpoint, describing the available query parameters and the expected response format, including an example of the returned data.

